### PR TITLE
del missing id field

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -150,7 +150,6 @@ pub struct Summary {
 pub struct VersionDownloads {
     pub date: NaiveDate,
     pub downloads: u64,
-    pub id: u64,
     pub version: u64,
 }
 


### PR DESCRIPTION
Removed unexistant `VersionDownloads.id` field

e.g. `https://crates.io/api/v1/crates/hyper-native-tls/downloads`